### PR TITLE
Refactor some credential handling and HTTP code, fix some bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,11 @@
             <version>2.3.0</version>
         </dependency>
 
-		<dependency>
-		    <groupId>com.google.code.gson</groupId>
-		    <artifactId>gson</artifactId>
-		    <version>2.10</version>
-		</dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
@@ -99,8 +99,7 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
 
     private HttpService httpService = null;
     private AuthenticationService authenticationService = null;
-    private HubInfoService hubInfoService = null;
-    
+
     private List<Condition> conditions;
 
     private String credentialId;
@@ -214,16 +213,10 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
         return (DescriptorImpl) super.getDescriptor();
     }
 
-    /**
-     * @return the hubAddress
-     */
     public String getHubAddress() {
         return hubAddress;
     }
 
-    /**
-     * @return the protocol
-     */
     public String getProtocol() {
         return protocol;
     }
@@ -232,33 +225,16 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
         this.protocol = protocol;
     }
 
-    /**
-     * @param hubAddress the hubAddress to set
-     */
     public void setHubAddress(String hubAddress) {
         this.hubAddress = hubAddress;
     }
 
-    /**
-     * @return the projectLocation
-     */
     public String getProjectName() {
         return projectName;
     }
 
-    /**
-     * @param projectName the projectLocation to set
-     */
     public void setProjectName(String projectName) {
         this.projectName = projectName;
-    }
-
-    public void setHttpService(HttpService httpService) {
-        this.httpService = httpService;
-    }
-    
-    public void setAuthenticationService(AuthenticationService authenticationService) {
-        this.authenticationService = authenticationService;
     }
 
     public String getCredentialId() {
@@ -267,6 +243,32 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
 
     public void setCredentialId(String credentialId) {
         this.credentialId = credentialId;
+    }
+
+    private HttpService getHttpService(@Nonnull Run<?,?> run) throws CodeSonarPluginException {
+        if (this.httpService == null)
+        {
+            this.httpService = createHttpService(run);
+        }
+        return this.httpService;
+    }
+
+    /** Used by unit tests. */
+    public void setHttpService(HttpService httpService) {
+        this.httpService = httpService;
+    }
+
+    private AuthenticationService getAuthenticationService(@Nonnull Run<?,?> run) throws CodeSonarPluginException {
+        if (this.authenticationService == null) {
+            this.authenticationService = new AuthenticationService(
+                getHttpService(run));
+        }
+        return this.authenticationService;
+    }
+
+    /** Used by unit tests. */
+    public void setAuthenticationService(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
     }
 
     private StandardCredentials lookupCredentials(String credentialId, Run<?,?> run) {
@@ -416,10 +418,6 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
             @Nonnull TaskListener listener)
             throws InterruptedException, IOException
     {
-        httpService = getHttpService(run);
-        authenticationService = getAuthenticationService(run);
-        hubInfoService = getHubInfoService(run);
-
         String expandedHubAddress = run.getEnvironment(listener).expand(Util.fixNull(hubAddress));
         String expandedProjectName = run.getEnvironment(listener).expand(Util.fixNull(projectName));
         LOGGER.log(Level.INFO, "projectName: {0} expandedProjectName {1}", new String[] {projectName, expandedProjectName});
@@ -439,11 +437,16 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
         URI baseHubUri = URI.create(String.format("%s://%s", getProtocol(), expandedHubAddress));
         csLogger.writeInfo("Using hub URI: {0}", baseHubUri);
 
+        HttpService httpService = getHttpService(run);
+        HubInfoService hubInfoService = new HubInfoService(httpService);
         CodeSonarHubInfo hubInfo = hubInfoService.fetchHubInfo(baseHubUri);
+        // Set hubInfo on httpService so that later users of httpService can get it.
+        //  TODO: It would be better if httpService could fetch hubInfo this itself.
         httpService.setHubInfo(hubInfo);
-        LOGGER.log(Level.FINE, "hub version: {0}", hubInfo.getVersion());
-        
-        authenticate(run, baseHubUri, hubInfo.isOpenAPISupported());
+        LOGGER.log(Level.INFO, "hub version: {0}", hubInfo.getVersion());
+
+        AuthenticationService authenticationService = getAuthenticationService(run);
+        authenticate(authenticationService, baseHubUri, csLogger, run);
 
         String currentAnalysisIdString = null;
         if(StringUtils.isBlank(aid)) {
@@ -566,22 +569,27 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
         csLogger.writeInfo("Done performing codesonar actions");
     }
     
-    private void authenticate(Run<?, ?> run, URI baseHubUri, boolean supportsOpenAPI) throws CodeSonarPluginException {
+    private void authenticate(
+                AuthenticationService authenticationService,
+                URI baseHubUri,
+                CodeSonarLogger csLogger,
+                Run<?, ?> run)
+            throws CodeSonarPluginException {
         String hubUserCredentialId = getCredentialId();
         StandardCredentials hubUserCredentials = lookupCredentials(hubUserCredentialId, run);
         if (hubUserCredentials == null) {
-            LOGGER.log(Level.INFO, "Authenticating as anonymous");
+            csLogger.writeInfo("Using hub URI: {0}", baseHubUri);
         } else if (hubUserCredentials instanceof StandardUsernamePasswordCredentials) {
-            LOGGER.log(Level.INFO, "Authenticating using username and password");
-            UsernamePasswordCredentials c = (UsernamePasswordCredentials) hubUserCredentials;
+            csLogger.writeInfo("Authenticating using username and password");
+            UsernamePasswordCredentials userPassCredentials = (UsernamePasswordCredentials) hubUserCredentials;
 
-            authenticationService.authenticate(baseHubUri,
-                    supportsOpenAPI,
-                    c.getUsername(),
-                    c.getPassword().getPlainText());
+            authenticationService.authenticate(
+                    baseHubUri,
+                    userPassCredentials.getUsername(),
+                    userPassCredentials.getPassword().getPlainText());
         } else if (hubUserCredentials instanceof StandardCertificateCredentials
                 || hubUserCredentials instanceof FileCredentials) {
-            LOGGER.log(Level.INFO, "Authenticating using SSL certificate");
+            csLogger.writeInfo("Authenticating using client certificate");
             if (protocol.equals("http")) {
                 throw createError("Authentication using a certificate is only available when using HTTPS protocol.");
             }
@@ -589,101 +597,79 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
             // Client certificate credentials must be applied to the authenticationService
             //  via the HttpService during creation;
             //  so assume that the credentials are already applied:
-            authenticationService.authenticate(baseHubUri,
-                    supportsOpenAPI);
+            authenticationService.authenticate(baseHubUri);
         } else {
-            LOGGER.log(Level.WARNING,
-                "Unrecognized credential type for credential \"{0}\": {1}",
-                new String[] {
+            throw createError(
+                    "Unrecognized credential type for credential \"{0}\": {1}",
                     hubUserCredentialId,
-                    hubUserCredentials.getClass().toString()});
-            throw createError("Unrecognized credential type for credential \"{0}\"", hubUserCredentialId);
+                    hubUserCredentials.getClass().getName());
         }
     }
 
-    public HttpService getHttpService(@Nonnull Run<?, ?> run) throws CodeSonarPluginException {
-        if (httpService == null) {
-            Collection<? extends Certificate> serverCertificates = null;
-            if (StringUtils.isNotEmpty(serverCertificateCredentialId)) {
-                serverCertificateCredentials = lookupCredentials(
-                    getServerCertificateCredentialId(),
-                    run);
-                if (serverCertificateCredentials instanceof FileCredentials) {
-                    LOGGER.log(Level.INFO, "Found FileCredentials provided as Hub HTTPS certificate");
-                    FileCredentials f = (FileCredentials) serverCertificateCredentials;
-                    try {
-                        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-                        serverCertificates = cf.generateCertificates(f.getContent());
-                        LOGGER.log(Level.INFO, "X509Certificate initialized");
-                    } catch (IOException | CertificateException e ) {
-                        throw createError("Failed to create X509Certificate from Secret File Credential.", e);
-                    }
-                } else {
-                    if (serverCertificateCredentials != null) {
-                        LOGGER.log(Level.INFO, "Found {0} provided as Hub HTTPS certificate", serverCertificateCredentials.getClass().getName());
-                        throw createError("The Jenkins Credentials provided as Hub HTTPS certificate is of type {0}.%nPlease provide a credential of type FileCredentials", serverCertificateCredentials.getClass().getName());
-                    }
-                    LOGGER.log(Level.INFO, "Credentials with id \"{0}\" not found", getServerCertificateCredentialId());
-                    throw createError(CodeSonarLogger.formatMessage("Credentials with id \"{0}\" not found", getServerCertificateCredentialId()));
+    private HttpService createHttpService(@Nonnull Run<?, ?> run) throws CodeSonarPluginException {
+        Collection<? extends Certificate> serverCertificates = null;
+        if (StringUtils.isNotEmpty(serverCertificateCredentialId)) {
+            serverCertificateCredentials = lookupCredentials(
+                getServerCertificateCredentialId(),
+                run);
+            if (serverCertificateCredentials == null) {
+                throw createError(CodeSonarLogger.formatMessage("Credentials with id \"{0}\" not found", getServerCertificateCredentialId()));
+            }
+            else if (serverCertificateCredentials instanceof FileCredentials) {
+                LOGGER.log(Level.INFO, "Found FileCredentials provided as Hub HTTPS certificate");
+                FileCredentials f = (FileCredentials) serverCertificateCredentials;
+                try {
+                    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                    serverCertificates = cf.generateCertificates(f.getContent());
+                    LOGGER.log(Level.INFO, "X509Certificate initialized");
+                } catch (IOException | CertificateException e ) {
+                    throw createError("Failed to create X509Certificate from Secret File Credential.", e);
+                }
+            } else {
+                throw createError("Invalid credential type provided for hub HTTPS certificate: {0}", serverCertificateCredentials.getClass().getName());
+            }
+        }
+        
+        KeyStore clientCertificateKeyStore = null;
+        Secret clientCertificatePassword = null;
+        String hubUserCredentialId = getCredentialId();
+        StandardCredentials hubUserCredentials = lookupCredentials(hubUserCredentialId, run);
+        if (StringUtils.isNotBlank(hubUserCredentialId) && hubUserCredentials == null) {
+            throw createError("Hub user credential ID not found: \"{0}\"", hubUserCredentialId);
+        } else if (hubUserCredentials != null) {
+            if (hubUserCredentials instanceof StandardCertificateCredentials) {
+                if (protocol.equals("http")) {
+                    throw createError("Authentication using a certificate is only available when using HTTPS protocol.");
+                }
+                LOGGER.log(Level.INFO, "Configuring HttpClient with certificate authentication using \"Certificate\" credentials parameter kind");
+                StandardCertificateCredentials certificateCredentials = (StandardCertificateCredentials) hubUserCredentials;
+                clientCertificateKeyStore = certificateCredentials.getKeyStore();
+                clientCertificatePassword = certificateCredentials.getPassword();
+            } else if(hubUserCredentials instanceof FileCredentials) {
+                LOGGER.log(Level.INFO, "Configuring HttpClient with certificate authentication using \"Secret File\" credentials parameter kind");
+                FileCredentials certificateFileCredentials = (FileCredentials) hubUserCredentials;
+                try {
+                    //Specify an empty-password secret
+                    clientCertificatePassword = Secret.fromString("");
+                    KeyStore keystore = KeyStore.getInstance("PKCS12");
+                    keystore.load(
+                        certificateFileCredentials.getContent(),
+                        clientCertificatePassword.getPlainText().toCharArray());
+                    clientCertificateKeyStore = keystore;
+                    LOGGER.log(Level.INFO, "Client PKCS12 keystore successfully imported");
+                } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+                    throw createError("Failed to create PKCS12 keystore from Secret File Credential.", e);
                 }
             }
-            
-            KeyStore clientCertificateKeyStore = null;
-            Secret clientCertificatePassword = null;
-            String hubUserCredentialId = getCredentialId();
-            StandardCredentials hubUserCredentials = lookupCredentials(hubUserCredentialId, run);
-            if (StringUtils.isNotBlank(hubUserCredentialId) && hubUserCredentials == null) {
-                throw createError("Hub user credential ID not found: \"{0}\"", hubUserCredentialId);
-            } else if (hubUserCredentials != null) {
-                if (hubUserCredentials instanceof StandardCertificateCredentials) {
-                    if (protocol.equals("http")) {
-                        throw createError("Authentication using a certificate is only available when using HTTPS protocol.");
-                    }
-                    LOGGER.log(Level.INFO, "Configuring HttpClient with certificate authentication using \"Certificate\" credentials parameter kind");
-                    StandardCertificateCredentials certificateCredentials = (StandardCertificateCredentials) hubUserCredentials;
-                    clientCertificateKeyStore = certificateCredentials.getKeyStore();
-                    clientCertificatePassword = certificateCredentials.getPassword();
-                } else if(hubUserCredentials instanceof FileCredentials) {
-                    LOGGER.log(Level.INFO, "Configuring HttpClient with certificate authentication using \"Secret File\" credentials parameter kind");
-                    FileCredentials certificateFileCredentials = (FileCredentials) hubUserCredentials;
-                    try {
-                        //Specify an empty-password secret
-                        clientCertificatePassword = Secret.fromString("");
-                        KeyStore keystore = KeyStore.getInstance("PKCS12");
-                        keystore.load(
-                            certificateFileCredentials.getContent(),
-                            clientCertificatePassword.getPlainText().toCharArray());
-                        clientCertificateKeyStore = keystore;
-                        LOGGER.log(Level.INFO, "Client PKCS12 keystore successfully imported");
-                    } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
-                        throw createError("Failed to create PKCS12 keystore from Secret File Credential.", e);
-                    }
-                }
-            }
-
-            httpService = new HttpService(
-                    serverCertificates,
-                    clientCertificateKeyStore,
-                    clientCertificatePassword,
-                    getSocketTimeoutMS());
         }
-        return httpService;
+
+        return new HttpService(
+                serverCertificates,
+                clientCertificateKeyStore,
+                clientCertificatePassword,
+                getSocketTimeoutMS());
     }
 
-    public AuthenticationService getAuthenticationService(@Nonnull Run<?, ?> run) throws CodeSonarPluginException {
-        if (authenticationService == null) {
-            authenticationService = new AuthenticationService(getHttpService(run));
-        }
-        return authenticationService;
-    }
-    
-    public HubInfoService getHubInfoService(@Nonnull Run<?, ?> run) throws CodeSonarPluginException {
-        if (hubInfoService == null) {
-            hubInfoService = new HubInfoService(getHttpService(run));
-        }
-        return hubInfoService;
-    }
-    
     @Symbol("codesonar")
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {

--- a/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
@@ -354,6 +354,7 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
         csLogger.writeInfo("Using hub URI: {0}", baseHubUri);
 
         CodeSonarHubInfo hubInfo = hubInfoService.fetchHubInfo(baseHubUri);
+        httpService.setHubInfo(hubInfo);
         LOGGER.log(Level.FINE, "hub version: {0}", hubInfo.getVersion());
         
         authenticate(run, baseHubUri, hubInfo.isOpenAPISupported());

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/AlertsService.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/AlertsService.java
@@ -45,7 +45,7 @@ public class AlertsService extends AbstractService {
             }
             String requestUriString = requestUri.toASCIIString();
             
-            LOGGER.log(Level.INFO, "Querying alerts with kind={0}", kind);
+            //LOGGER.log(Level.INFO, "Querying alerts with kind={0}", kind);
             HttpServiceResponse response = null;
             try {
                 response = httpService.getResponseFromUrl(requestUriString);
@@ -57,7 +57,7 @@ public class AlertsService extends AbstractService {
                      * A 404 response is expected to be returned anytime the request specifies an alert kind that has no
                      * occurrences on the specified analysis
                      */
-                    LOGGER.log(Level.INFO, "HTTP 404: no alerts found for kind={0}", kind);
+                    //LOGGER.log(Level.INFO, "HTTP 404: no alerts found for kind={0}", kind);
                     foundExpectedResponse = true;
                     continue;
                 } else if(response.getStatusCode() == 500) {

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/CodeSonarHubAnalysisDataLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/CodeSonarHubAnalysisDataLoader.java
@@ -201,7 +201,11 @@ public class CodeSonarHubAnalysisDataLoader {
         if(hubInfo.isJsonGridConfigSupported()) {
             if(numberOfWarningsAboveThreshold.get(threshold) == null) {
                 LOGGER.log(Level.INFO, "NumberOfWarningsAboveThreshold not already set for threshold {0}, loading from corresponding service", threshold);
-                long numberOfWarnings = services.getWarningsService().getNumberOfWarningsWithScoreAboveThreshold(getBaseHubUri(), getAnalysisId(), threshold);
+                long numberOfWarnings = services.getWarningsService().getNumberOfWarningsWithScoreAboveThreshold(
+                        getBaseHubUri(),
+                        getAnalysisId(),
+                        threshold,
+                        visibilityFilter);
                 numberOfWarningsAboveThreshold.put(threshold, numberOfWarnings);
                 LOGGER.log(Level.INFO, "NumberOfWarningsAboveThreshold new value {0}", numberOfWarnings);
             }

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/HttpServiceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/HttpServiceRequest.java
@@ -12,14 +12,15 @@ import org.jenkinsci.plugins.codesonar.CodeSonarPluginException;
 
 /** Provides extended properties for a CodeSonar hub request. */
 public class HttpServiceRequest {
-    private URI uri;
-    private String uriString;
-    private Collection<Map.Entry<String,String>> headers;
+    private final URI uri;
+    private final String uriString;
+    private final Collection<Map.Entry<String,String>> headers;
 
     public HttpServiceRequest(URI uri) throws CodeSonarPluginException {
         if (uri == null) {
             throw new CodeSonarPluginException("URI cannot be null");
         }
+        // TODO can we avoid storing both URI and String?
         this.uri = uri;
         this.uriString = uri.toString();
         this.headers = new ArrayList<Map.Entry<String,String>>(4);
@@ -34,6 +35,7 @@ public class HttpServiceRequest {
         } catch (URISyntaxException ex) {
             throw new CodeSonarPluginException("Could not parse URI", ex);
         }
+        // TODO can we avoid storing both URI and String?
         this.uriString = uri;
         this.headers = new ArrayList<Map.Entry<String,String>>(4);
     }

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/HttpServiceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/HttpServiceRequest.java
@@ -1,0 +1,57 @@
+package org.jenkinsci.plugins.codesonar.services;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import org.jenkinsci.plugins.codesonar.CodeSonarPluginException;
+
+
+/** Provides extended properties for a CodeSonar hub request. */
+public class HttpServiceRequest {
+    private URI uri;
+    private String uriString;
+    private Collection<Map.Entry<String,String>> headers;
+
+    public HttpServiceRequest(URI uri) throws CodeSonarPluginException {
+        if (uri == null) {
+            throw new CodeSonarPluginException("URI cannot be null");
+        }
+        this.uri = uri;
+        this.uriString = uri.toString();
+        this.headers = new ArrayList<Map.Entry<String,String>>(4);
+    }
+
+    public HttpServiceRequest(String uri) throws CodeSonarPluginException {
+        if (uri == null) {
+            throw new CodeSonarPluginException("URI cannot be null");
+        }
+        try {
+            this.uri = new URI(uri);
+        } catch (URISyntaxException ex) {
+            throw new CodeSonarPluginException("Could not parse URI", ex);
+        }
+        this.uriString = uri;
+        this.headers = new ArrayList<Map.Entry<String,String>>(4);
+    }
+
+    public String getURIString() {
+        return this.uriString;
+    }
+
+    public URI getURI() {
+        return this.uri;
+    }
+
+    public Collection<Map.Entry<String,String>> getHeaderCollection() {
+        return this.headers;
+    }
+
+    public HttpServiceRequest addHeader(String name, String value) {
+        this.headers.add(new AbstractMap.SimpleEntry<String,String>(name, value));
+        return this;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/codesonar/services/HttpServiceResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/services/HttpServiceResponse.java
@@ -1,13 +1,14 @@
 package org.jenkinsci.plugins.codesonar.services;
 
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 
-public class HttpServiceResponse {
+public class HttpServiceResponse implements Closeable {
 
     private int statusCode;
     private String reasonPhrase;
@@ -17,6 +18,12 @@ public class HttpServiceResponse {
         this.statusCode = statusCode;
         this.reasonPhrase = reasonPhrase;
         this.contentInputStream = contentInputStream;
+    }
+
+    public void close() throws IOException {
+        if (this.contentInputStream != null) {
+            this.contentInputStream.close();
+        }
     }
 
     public int getStatusCode() {

--- a/src/test/java/org/jenkinsci/plugins/codesonar/unit/services/AnalysisServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/codesonar/unit/services/AnalysisServiceTest.java
@@ -29,6 +29,7 @@ import org.jenkinsci.plugins.codesonar.models.analysis.Analysis;
 import org.jenkinsci.plugins.codesonar.models.projects.Project;
 import org.jenkinsci.plugins.codesonar.services.AnalysisService;
 import org.jenkinsci.plugins.codesonar.services.HttpService;
+import org.jenkinsci.plugins.codesonar.services.HttpServiceRequest;
 import org.jenkinsci.plugins.codesonar.services.HttpServiceResponse;
 import org.jenkinsci.plugins.codesonar.services.IAnalysisService;
 import org.jenkinsci.plugins.codesonar.services.XmlSerializationService;
@@ -117,6 +118,7 @@ public class AnalysisServiceTest {
         
 
         when(mockedHttpService.getExecutor()).thenReturn(executor);
+        when(mockedHttpService.getResponse(notNull(HttpServiceRequest.class))).thenCallRealMethod();
         when(mockedHttpService.getResponseFromUrl(notNull(URI.class))).thenCallRealMethod();
         when(mockedHttpService.getResponseFromUrl(any(String.class))).thenCallRealMethod();
 
@@ -152,6 +154,7 @@ public class AnalysisServiceTest {
         Executor executor = Executor.newInstance(httpClient).use(httpCookieStore);
         
         when(mockedHttpService.getExecutor()).thenReturn(executor);
+        when(mockedHttpService.getResponse(any(HttpServiceRequest.class))).thenCallRealMethod();
         when(mockedHttpService.getResponseFromUrl(any(String.class))).thenCallRealMethod();
         analysisService.getAnalysisFromUrl(INVALID_ANALYSIS_URL);
     }


### PR DESCRIPTION
- Make threshold/score conditions use configured visibility filter instead of hard-coded "all".
- Don't request "response_try_plaintext" for CS 7.2 and later.
- Expand HttpService to allow headers to be passed with requests (e.g. Accept header).
- Check for invalid or unresolvable client credentials.
- Refactor some service handling code to consolidate some resources.